### PR TITLE
feat: dockerizing finished

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+/node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12-alpine
+FROM node:12-alpine AS BUILD_IMAGE
 
 WORKDIR /rs-cart
 
@@ -7,6 +7,14 @@ RUN npm install
 
 COPY . .
 RUN npm run build
+
+FROM node:12-alpine
+
+WORKDIR /rs-cart
+
+COPY --from=BUILD_IMAGE /rs-cart/package*.json ./
+COPY --from=BUILD_IMAGE /rs-cart/dist ./dist
+RUN npm install --only=prod
 
 USER node
 ENV PORT=8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:12-alpine
+
+WORKDIR /rs-cart
+
+COPY package*.json ./
+RUN npm install
+
+COPY . .
+RUN npm run build
+
+USER node
+ENV PORT=8080
+EXPOSE 8080
+
+CMD ["node", "dist/main.js"]


### PR DESCRIPTION
Build with ```docker build -t rs-image . ``` be sure what you are in the project root
Run with ```docker run -p 8000:8080 -d rs-image```
**Image Size** - near 100mb
![image](https://user-images.githubusercontent.com/62539527/101288058-6f67d600-3805-11eb-8f68-c49b4bfc2b16.png)

Api link: http://kabolov-cart-api-test.eu-west-1.elasticbeanstalk.com
FE modify: https://github.com/kabolov/nodejs-aws-fe/blob/main/src/constants/apiPaths.ts

expected mark - 5/5
